### PR TITLE
Preserve existing front matter when sharing as a gist

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -124,7 +124,7 @@ const shareGistEditorCallback =
         if (enableUpdatingGistsAfterCreation) {
           const updatedContent = upsertSharedGistForFile(
             result.sharedGist,
-            content,
+            rawContent,
           );
 
           app.vault.modify(view.file, updatedContent);


### PR DESCRIPTION
This fixes a bug reported in #253 where sharing as a gist with the "Enable updating gists after creation" option turned on would delete existing YAML front matter in the note.

Fixes #253.