### PR TITLE
Splitting properties across separate fields.

### DIFF
--- a/src/shared-gists.ts
+++ b/src/shared-gists.ts
@@ -22,23 +22,24 @@ export const upsertSharedGistForFile = (
   fileContents: string,
 ): string => {
   const { data, content } = matter(fileContents);
-  const existingSharedGists = (data.gists || []) as SharedGist[];
-
-  const matchingGist = existingSharedGists.find(
-    (existingSharedGist) => existingSharedGist.id === sharedGist.id,
-  );
-
-  if (matchingGist) {
-    const otherGists = existingSharedGists.filter(
-      (existingSharedGist) => existingSharedGist !== matchingGist,
-    );
-
-    const gists = [...otherGists, sharedGist];
-    const updatedData = { ...data, gists };
-    return matter.stringify(content, updatedData);
-  } else {
-    const gists = [...existingSharedGists, sharedGist];
-    const updatedData = { ...data, gists };
-    return matter.stringify(content, updatedData);
+  
+  // Initialize the gists data structure if it doesn't exist
+  if (!data.gists) {
+    data.gists = {};
   }
+
+  // Extracting each sub-property of the shared gist
+  const gistKey = `gist-${sharedGist.id}`;
+  data.gists[gistKey] = {
+    id: sharedGist.id,
+    url: sharedGist.url,
+    createdAt: sharedGist.createdAt,
+    updatedAt: sharedGist.updatedAt,
+    filename: sharedGist.filename,
+    isPublic: sharedGist.isPublic
+  };
+
+  // Reconstructing the front matter with updated gist data
+  const updatedData = { ...data };
+  return matter.stringify(content, updatedData);
 };


### PR DESCRIPTION
I changed the upsertSharedGistForFile function to add seperate fields for each property of a shared note. Especially useful to quickly acces a url.

As is to be expected this caused issues elsewhere in the code. Specifically the github API gave me the following error: 
`github api error: validation failed: {"resource":"Gist","code":"missing_field","field":"files"}`
I tried to look into this myself, but after an hour I can't seem to locate the error (I don't even know how to get an error log).
So this is where this fork probably dies, unless one of you can find the issue?