### PR TITLE
Allow setting the description when creating a gist

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This plugin for Obsidian (https://obsidian.md) allows you to share your notes as [GitHub Gists](https://gist.github.com/).
 
-You can share your notes privately (i.e. only people with the link can see the note) or publicly (i.e. the note is visible on your profile).
+You can share your notes privately (i.e. only people with the link can see the note) or publicly (i.e. the note is visible on your profile). Optionally, you can also set a description for your gist.
 
 Once you've create a gist, if you make changes to your note (for example responding to feedback), you can update your existing gist straight from Obsidian - or even configure this to happen automatically every time you save.
 
@@ -19,9 +19,13 @@ Once you've create a gist, if you make changes to your note (for example respond
 
 4. Paste your access token into the "GitHub.com access token" box, then close "Settings".
 
-5. To share a note, open the Command Palette and type "gist". You'll see commands for creating a public and private link. Pick the one you want and hit enter. Your gist will be created, and the URL for sharing will be added to your clipboard.
+5. To share a note, open the Command Palette and type "gist". You'll see commands for creating a public and private link. Pick the one you want and hit enter. 
 
 <img width="770" alt="Screenshot 2022-07-21 at 09 12 16" src="https://user-images.githubusercontent.com/116134/180164154-02817121-e88a-419d-9528-9be58212ed9c.png">
+
+6. Add a custom description for your gist and hit Enter. You can skip this and accept the default by hitting Enter immediately.
+
+7. Your gist will be created, and the URL for sharing will be added to your clipboard.
 
 6. Make a change to your note.
 

--- a/README.md
+++ b/README.md
@@ -23,9 +23,12 @@ Once you've create a gist, if you make changes to your note (for example respond
 
 <img width="770" alt="Screenshot 2022-07-21 at 09 12 16" src="https://user-images.githubusercontent.com/116134/180164154-02817121-e88a-419d-9528-9be58212ed9c.png">
 
-6. Add a custom description for your gist and hit Enter. You can skip this and accept the default by hitting Enter immediately.
+6. Optionally, add a custom description for your gist, and hit Enter. You can skip this and accept the default by hitting Enter immediately.
 
-7. Your gist will be created, and the URL for sharing will be added to your clipboard.
+![Screenshot 2024-05-16 at 20 35 55](https://github.com/timrogers/obsidian-share-as-gist/assets/116134/04f5fe00-8fc3-4e9c-8db9-55a83d52f970)
+
+8. Your gist will be created, and the URL for sharing will be added to your clipboard.
+
 
 6. Make a change to your note.
 

--- a/src/gists.ts
+++ b/src/gists.ts
@@ -14,6 +14,7 @@ export interface CreateGistResult {
 
 interface CreateGistOptions {
   filename: string;
+  description: string | null;
   content: string;
   isPublic: boolean;
   accessToken: string;
@@ -60,14 +61,14 @@ export const createGist = async (
   opts: CreateGistOptions,
 ): Promise<CreateGistResult> => {
   try {
-    const { filename, content, isPublic, accessToken } = opts;
+    const { accessToken, content, description, filename, isPublic } = opts;
 
     const octokit = new Octokit({
       auth: accessToken,
     });
 
     const response = await octokit.rest.gists.create({
-      description: filename,
+      description: description || filename,
       public: isPublic,
       files: {
         [filename]: { content },


### PR DESCRIPTION
Gists can have descriptions which are shown in the GitHub UI. At the moment, the description is always set to the filename of the file you are sharing.

This adds a new (skippable) UI for setting a custom description. The value defaults to the filename to preserve current behaviour.

![image](https://github.com/timrogers/obsidian-share-as-gist/assets/116134/40c3cbbd-a084-437f-9726-154b077d31ec)

Closes #564.