### PR TITLE
Add command for opening the current note's gist on GitHub.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Once you've create a gist, if you make changes to your note (for example respond
 
 8. If you want to get the URL of your gist after creating it, open the Command Palette and type "gist". Pick the "Copy GitHub.com gist URL" command. If you have multiple gists for your note, you'll have to pick which one you want the URL for.
 
+9. To open your gist after creating it, open the Command Palette and find the "Open gist on GitHub.com" command.  If you have multiple gists for your note, you'll have to pick which one you want to open.
+
 ## Customisable settings
 
 * __Enable updating gists after creation__ (*enabled by default*): Allow gists to be updated after creation. To enable this to work, information about the gists you create will be stored on notes as  front matter (properties).

--- a/main.ts
+++ b/main.ts
@@ -61,7 +61,7 @@ const getLatestSettings = async (
 
 const stripFrontMatter = (content: string): string => matter(content).content;
 
-const copyGitUrlEditorCallback =
+const copyGistUrlEditorCallback =
   (opts: CopyGistUrlEditorCallbackParams) => async () => {
     const { app, plugin } = opts;
 
@@ -295,7 +295,7 @@ export default class ShareAsGistPlugin extends Plugin {
     this.addCommand({
       id: 'copy-gist-url',
       name: 'Copy GitHub.com gist URL',
-      callback: copyGitUrlEditorCallback({
+      callback: copyGistUrlEditorCallback({
         plugin: this,
         app: this.app,
       }),


### PR DESCRIPTION
This adds a new "Open gist on GitHub.com" command, alongside the "Copy GitHub.com gist URL" command, which allows you to open the current note's gist on GitHub.com, if it has been shared as a gist.

As with "Copy GitHub.com gist URL", this only works if the 'Update gists after creation' setting is enabled, and the note has been shared as a gist. If there are multiple gists recorded, the picker UI will be displayed to choose which one to open.