### PR TITLE
Don't insert extra lines in the note when hitting Enter in the "Set a description for your gist" modal

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -498,6 +498,8 @@ class SetGistDescriptionModal extends Modal {
     );
 
     this.scope.register([], 'Enter', (evt: KeyboardEvent) => {
+      evt.preventDefault();
+
       if (evt.isComposing) {
         return;
       }


### PR DESCRIPTION
Fixes #602.