### PR TITLE
Allow updating the GitHub API base URL 

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,24 +19,26 @@ Once you've create a gist, if you make changes to your note (for example respond
 
 4. Paste your access token into the "GitHub.com access token" box, then close "Settings".
 
-5. To share a note, open the Command Palette and type "gist". You'll see commands for creating a public and private link. Pick the one you want and hit enter. 
+5. Optionally, update the GitHub REST API base URL. Required for GitHub enterprise.
+
+6. To share a note, open the Command Palette and type "gist". You'll see commands for creating a public and private link. Pick the one you want and hit enter. 
 
 <img width="770" alt="Screenshot 2022-07-21 at 09 12 16" src="https://user-images.githubusercontent.com/116134/180164154-02817121-e88a-419d-9528-9be58212ed9c.png">
 
-6. Optionally, add a custom description for your gist, and hit Enter. You can skip this and accept the default by hitting Enter immediately.
+7. Optionally, add a custom description for your gist, and hit Enter. You can skip this and accept the default by hitting Enter immediately.
 
 ![Screenshot 2024-05-16 at 20 35 55](https://github.com/timrogers/obsidian-share-as-gist/assets/116134/04f5fe00-8fc3-4e9c-8db9-55a83d52f970)
 
 8. Your gist will be created, and the URL for sharing will be added to your clipboard.
 
 
-6. Make a change to your note.
+9. Make a change to your note.
 
-7. If the "Enable auto-saving Gists after edit" setting is turned on, your changes will automatically be reflected in your gist. If not, you can use the "Share as [public|private] gist on GitHub.com" command" again to update your gist, or create a fresh one. 
+10. If the "Enable auto-saving Gists after edit" setting is turned on, your changes will automatically be reflected in your gist. If not, you can use the "Share as [public|private] gist on GitHub.com" command" again to update your gist, or create a fresh one. 
 
-8. If you want to get the URL of your gist after creating it, open the Command Palette and type "gist". Pick the "Copy GitHub.com gist URL" command. If you have multiple gists for your note, you'll have to pick which one you want the URL for.
+11. If you want to get the URL of your gist after creating it, open the Command Palette and type "gist". Pick the "Copy GitHub.com gist URL" command. If you have multiple gists for your note, you'll have to pick which one you want the URL for.
 
-9. To open your gist after creating it, open the Command Palette and find the "Open gist on GitHub.com" command.  If you have multiple gists for your note, you'll have to pick which one you want to open.
+12. To open your gist after creating it, open the Command Palette and find the "Open gist on GitHub.com" command.  If you have multiple gists for your note, you'll have to pick which one you want to open.
 
 ## Customisable settings
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
 				"eslint": "^8.57.0",
 				"eslint-config-prettier": "^9.1.0",
 				"eslint-plugin-prettier": "^5.1.3",
-				"obsidian": "*",
+				"obsidian": "latest",
 				"prettier": "^3.3.3",
 				"tslib": "2.6.3",
 				"typescript": "5.5.3"

--- a/src/gists.ts
+++ b/src/gists.ts
@@ -18,22 +18,25 @@ interface CreateGistOptions {
   content: string;
   isPublic: boolean;
   accessToken: string;
+  baseUrl: string | null;
 }
 
 interface UpdateGistOptions {
   sharedGist: SharedGist;
   content: string;
   accessToken: string;
+  baseUrl: string | null;
 }
 
 export const updateGist = async (
   opts: UpdateGistOptions,
 ): Promise<CreateGistResult> => {
-  const { accessToken, sharedGist, content } = opts;
+  const { accessToken, baseUrl, sharedGist, content } = opts;
 
   try {
     const octokit = new Octokit({
       auth: accessToken,
+      baseUrl: baseUrl,
     });
 
     const response = await octokit.rest.gists.update({
@@ -61,10 +64,12 @@ export const createGist = async (
   opts: CreateGistOptions,
 ): Promise<CreateGistResult> => {
   try {
-    const { accessToken, content, description, filename, isPublic } = opts;
+    const { accessToken, baseUrl, content, description, filename, isPublic } =
+      opts;
 
     const octokit = new Octokit({
       auth: accessToken,
+      baseUrl: baseUrl,
     });
 
     const response = await octokit.rest.gists.create({

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,6 +1,12 @@
 const ACCESS_TOKEN_LOCAL_STORAGE_KEY = 'share_as_gist_dotcom_access_token';
+const BASE_URL_LOCAL_STORAGE_KEY = 'share_as_gist_dotcom_base_url';
 
 export const getAccessToken = (): string =>
   localStorage.getItem(ACCESS_TOKEN_LOCAL_STORAGE_KEY);
 export const setAccessToken = (accessToken: string): void =>
   localStorage.setItem(ACCESS_TOKEN_LOCAL_STORAGE_KEY, accessToken);
+
+export const getBaseUrl = (): string =>
+  localStorage.getItem(BASE_URL_LOCAL_STORAGE_KEY);
+export const setBaseUrl = (baseUrl: string): void =>
+  localStorage.setItem(BASE_URL_LOCAL_STORAGE_KEY, baseUrl);


### PR DESCRIPTION
This PR allows users to set the GitHub API base URL to be used by the octokit constructor. Similar to access token, the URL in localstorage, meaning it won't be synced with the rest of the vault. This is useful if you use the same vault both at work and personal, which is what I do at the moment, so you can set separate URLs depending on the machine. 

Closes #629 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an option for users to update the GitHub REST API base URL, especially beneficial for GitHub Enterprise users.
	- Added a setting in the application to input and save a custom GitHub REST API base URL.

- **Documentation**
	- Updated the README.md to clarify the steps for sharing notes via GitHub Gists, including the new base URL option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->