### PR TITLE
Add support for GitHub Enterprise Server (GHES)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,53 +1,54 @@
 # "Share as Gist" Obsidian plugin
 
-This plugin for Obsidian (https://obsidian.md) allows you to share your notes as [GitHub Gists](https://gist.github.com/).
+This plugin for Obsidian (https://obsidian.md) allows you to share your notes as [GitHub Gists](https://gist.github.com/)
 
-You can share your notes privately (i.e. only people with the link can see the note) or publicly (i.e. the note is visible on your profile). Optionally, you can also set a description for your gist.
-
-Once you've create a gist, if you make changes to your note (for example responding to feedback), you can update your existing gist straight from Obsidian - or even configure this to happen automatically every time you save.
+- 🔒 Share your notes privately or publicly
+- 💼 Works with GitHub.com and [GitHub Enterprise Server](https://docs.github.com/en/enterprise-server/admin/overview/about-github-enterprise-server)
+- 🔄 Update your gist when you make changes to your notes
 
 ## Usage
 
 1. [Install the plugin](https://obsidian.md/plugins?id=obsidian-share-as-gist).
-2. [Create a GitHub personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token). You can use a classic personal access token (PAT) with the `gist` scope, or a new fine-grained token with read-write access to your Gists.
+1. [Create a GitHub personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) on GitHub.com or your GitHub Enterprise Server instance. You can use a classic personal access token (PAT) with the `gist` scope, or a new fine-grained token with read-write access to your Gists.
 
 <img width="636" alt="Screenshot 2022-06-09 at 09 47 43" src="https://user-images.githubusercontent.com/116134/172805660-4e563a93-a042-4aa7-8b48-db0c501aac14.png">
 
-3. Open "Settings" in Obsidian, then go to "Share as Gist" under "Plugin Options".
+1. Open "Settings" in Obsidian, then go to "Share as Gist" in the "Plugin Options" tab.
 
 <img width="976" alt="Screenshot 2022-07-21 at 09 10 52" src="https://user-images.githubusercontent.com/116134/180163869-4a072203-00e6-4510-81e8-456dd71c5443.png">
 
-4. Paste your access token into the "GitHub.com access token" box, then close "Settings".
+1. Paste the access token into the relevant field. There are different sections for GitHub.com and GitHub Enterprise Server.
 
-5. To share a note, open the Command Palette and type "gist". You'll see commands for creating a public and private link. Pick the one you want and hit enter. 
+1. If you're using GitHub Enterprise Server, fill in the API base URL of your instance, ending with `/api/v3` (e.g. `https://github.business.com/api/v3`).
+
+1. To share a note, open the Command Palette and type "gist". You'll see commands for creating a public and private link. Pick the one you want and hit enter.
 
 <img width="770" alt="Screenshot 2022-07-21 at 09 12 16" src="https://user-images.githubusercontent.com/116134/180164154-02817121-e88a-419d-9528-9be58212ed9c.png">
 
-6. Optionally, add a custom description for your gist, and hit Enter. You can skip this and accept the default by hitting Enter immediately.
+1. Optionally, add a custom description for your gist, and hit Enter. You can skip this and accept the default by hitting Enter immediately.
 
 ![Screenshot 2024-05-16 at 20 35 55](https://github.com/timrogers/obsidian-share-as-gist/assets/116134/04f5fe00-8fc3-4e9c-8db9-55a83d52f970)
 
-8. Your gist will be created, and the URL for sharing will be added to your clipboard.
+1. Your gist will be created, and the URL for sharing will be added to your clipboard.
 
+1. Make a change to your note.
 
-6. Make a change to your note.
+1. If the "Enable auto-saving Gists after edit" setting is turned on, your changes will automatically be reflected in your gist. If not, you can use the "Share as [public|private] gist on GitHub.com" command" again to update your gist, or create a fresh one.
 
-7. If the "Enable auto-saving Gists after edit" setting is turned on, your changes will automatically be reflected in your gist. If not, you can use the "Share as [public|private] gist on GitHub.com" command" again to update your gist, or create a fresh one. 
+1. If you want to get the URL of your gist after creating it, open the Command Palette and type "gist". Pick the "Copy gist URL" command. If you have multiple gists for your note, you'll have to pick which one you want the URL for.
 
-8. If you want to get the URL of your gist after creating it, open the Command Palette and type "gist". Pick the "Copy GitHub.com gist URL" command. If you have multiple gists for your note, you'll have to pick which one you want the URL for.
-
-9. To open your gist after creating it, open the Command Palette and find the "Open gist on GitHub.com" command.  If you have multiple gists for your note, you'll have to pick which one you want to open.
+1. To open your gist after creating it, open the Command Palette and find the "Open gist" command. If you have multiple gists for your note, you'll have to pick which one you want to open.
 
 ## Customisable settings
 
-* __Enable updating gists after creation__ (*enabled by default*): Allow gists to be updated after creation. To enable this to work, information about the gists you create will be stored on notes as  front matter (properties).
-* __Include front matter in gists__ (*disabled by default*): Whether your gists should include frontmatter (properties). If this is disabled, the front matter will be stripped from your gists.
-* __Enable auto-saving Gists after edit__ (*disabled by default*): Whether your gists should be automatically updated when you save your note. If this is disabled, you can update your gists automatically with the normal "share" command.
-* __Enable auto-save notice__ (*disabled by default*): Whether a notice should be displayed when your gists are automatically updated. This option is only relevant if the "Enable auto-saving Gists after edit" option above is turned on.
+- **Enable updating gists after creation** (_enabled by default_): Allow gists to be updated after creation. To enable this to work, information about the gists you create will be stored on notes as front matter (properties).
+- **Include front matter in gists** (_disabled by default_): Whether your gists should include frontmatter (properties). If this is disabled, the front matter will be stripped from your gists.
+- **Enable auto-saving Gists after edit** (_disabled by default_): Whether your gists should be automatically updated when you save your note. If this is disabled, you can update your gists automatically with the normal "share" command.
+- **Enable auto-save notice** (_disabled by default_): Whether a notice should be displayed when your gists are automatically updated. This option is only relevant if the "Enable auto-saving Gists after edit" option above is turned on.
 
-## Securing your GitHub personal access token
+## Securing your GitHub personal access token(s)
 
-Your GitHub access token will be stored in Obsidian's `localStorage`.
+Your GitHub access token(s) will be stored in Obsidian's `localStorage`.
 
 This means that it will not be stored in a file and will not be backed up or synced with the rest of your Vault. But it is theoretically possible for other Obsidian plugins to access it.
 

--- a/src/shared-gists.ts
+++ b/src/shared-gists.ts
@@ -1,4 +1,5 @@
 import matter from 'gray-matter';
+import { DOTCOM_BASE_URL, Target } from './gists';
 
 export interface SharedGist {
   id: string;
@@ -7,14 +8,32 @@ export interface SharedGist {
   createdAt: string;
   updatedAt: string;
   filename: string;
+  baseUrl: string;
 }
 
-export const getSharedGistsForFile = (fileContents: string): SharedGist[] => {
+export const getBaseUrlForSharedGist = (sharedGist: SharedGist): string =>
+  sharedGist.baseUrl || DOTCOM_BASE_URL;
+
+export const getTargetForSharedGist = (sharedGist: SharedGist): Target =>
+  getBaseUrlForSharedGist(sharedGist) === DOTCOM_BASE_URL
+    ? Target.Dotcom
+    : Target.GitHubEnterpriseServer;
+
+export const getSharedGistsForFile = (
+  fileContents: string,
+  target?: Target,
+): SharedGist[] => {
   const { data } = matter(fileContents);
 
   const gists = data.gists || [];
 
-  return gists as SharedGist[];
+  return (gists as SharedGist[]).filter((gist) => {
+    if (typeof target === 'undefined') {
+      return true;
+    }
+
+    return getTargetForSharedGist(gist) === target;
+  });
 };
 
 export const upsertSharedGistForFile = (

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,6 +1,61 @@
-const ACCESS_TOKEN_LOCAL_STORAGE_KEY = 'share_as_gist_dotcom_access_token';
+import { DOTCOM_BASE_URL, Target } from './gists';
 
-export const getAccessToken = (): string =>
-  localStorage.getItem(ACCESS_TOKEN_LOCAL_STORAGE_KEY);
-export const setAccessToken = (accessToken: string): void =>
-  localStorage.setItem(ACCESS_TOKEN_LOCAL_STORAGE_KEY, accessToken);
+const DOTCOM_ACCESS_TOKEN_LOCAL_STORAGE_KEY =
+  'share_as_gist_dotcom_access_token';
+const GHES_BASE_URL_LOCAL_STORAGE_KEY = 'share_as_gist_ghes_base_url';
+const GHES_ACCESS_TOKEN_LOCAL_STORAGE_KEY = 'share_as_gist_ghes_access_token';
+
+export const getDotcomAccessToken = (): string =>
+  localStorage.getItem(DOTCOM_ACCESS_TOKEN_LOCAL_STORAGE_KEY);
+export const setDotcomAccessToken = (accessToken: string): void =>
+  localStorage.setItem(DOTCOM_ACCESS_TOKEN_LOCAL_STORAGE_KEY, accessToken);
+
+export const isDotcomEnabled = (): boolean => !!getDotcomAccessToken();
+
+export const getGhesBaseUrl = (): string =>
+  localStorage.getItem(GHES_BASE_URL_LOCAL_STORAGE_KEY);
+export const setGhesBaseUrl = (baseUrl: string): void =>
+  localStorage.setItem(GHES_BASE_URL_LOCAL_STORAGE_KEY, baseUrl);
+
+export const getGhesAccessToken = (): string =>
+  localStorage.getItem(GHES_ACCESS_TOKEN_LOCAL_STORAGE_KEY);
+export const setGhesAccessToken = (accessToken: string): void =>
+  localStorage.setItem(GHES_ACCESS_TOKEN_LOCAL_STORAGE_KEY, accessToken);
+
+export const isGhesEnabled = (): boolean =>
+  !!getGhesBaseUrl() && !!getGhesAccessToken();
+
+export const isTargetEnabled = (target: Target): boolean => {
+  switch (target) {
+    case Target.Dotcom:
+      return isDotcomEnabled();
+    case Target.GitHubEnterpriseServer:
+      return isGhesEnabled();
+  }
+};
+
+export const getTargetBaseUrl = (target: Target): string => {
+  switch (target) {
+    case Target.Dotcom:
+      return DOTCOM_BASE_URL;
+    case Target.GitHubEnterpriseServer:
+      return getGhesBaseUrl();
+  }
+};
+
+export const getTargetAccessToken = (target: Target): string => {
+  switch (target) {
+    case Target.Dotcom:
+      return getDotcomAccessToken();
+    case Target.GitHubEnterpriseServer:
+      return getGhesAccessToken();
+  }
+};
+
+export const getAccessTokenForBaseUrl = (baseUrl: string): string => {
+  if (baseUrl === DOTCOM_BASE_URL) {
+    return getDotcomAccessToken();
+  } else {
+    return getGhesAccessToken();
+  }
+};


### PR DESCRIPTION
This updates the plugin to support GitHub Enterprise Server (GHES) as well as GitHub.com.

It does this by adding an extra section to the plugin's settings for adding a GHES base URL and access token, and adding new command palette commands to share on GitHub Enterprise Server.