### PR TITLE
Bump @typescript-eslint/parser from 8.59.0 to 8.59.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
 				"@eslint/js": "^10.0.1",
 				"@types/node": "^25.6.0",
 				"@typescript-eslint/eslint-plugin": "^8.59.0",
-				"@typescript-eslint/parser": "^8.59.0",
+				"@typescript-eslint/parser": "^8.59.1",
 				"builtin-modules": "^5.1.0",
 				"esbuild": "0.28.0",
 				"eslint": "^10.0.1",
@@ -1016,15 +1016,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "8.59.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.0.tgz",
-			"integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
+			"version": "8.59.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.1.tgz",
+			"integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.59.0",
-				"@typescript-eslint/types": "8.59.0",
-				"@typescript-eslint/typescript-estree": "8.59.0",
-				"@typescript-eslint/visitor-keys": "8.59.0",
+				"@typescript-eslint/scope-manager": "8.59.1",
+				"@typescript-eslint/types": "8.59.1",
+				"@typescript-eslint/typescript-estree": "8.59.1",
+				"@typescript-eslint/visitor-keys": "8.59.1",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -1037,6 +1037,165 @@
 			"peerDependencies": {
 				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
 				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
+		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/project-service": {
+			"version": "8.59.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.1.tgz",
+			"integrity": "sha512-+MuHQlHiEr00Of/IQbE/MmEoi44znZHbR/Pz7Opq4HryUOlRi+/44dro9Ycy8Fyo+/024IWtw8m4JUMCGTYxDg==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/tsconfig-utils": "^8.59.1",
+				"@typescript-eslint/types": "^8.59.1",
+				"debug": "^4.4.3"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
+		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
+			"version": "8.59.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.1.tgz",
+			"integrity": "sha512-LwuHQI4pDOYVKvmH2dkaJo6YZCSgouVgnS/z7yBPKBMvgtBvyLqiLy9Z6b7+m/TRcX1NFYUqZetI5Y+aT4GEfg==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "8.59.1",
+				"@typescript-eslint/visitor-keys": "8.59.1"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/tsconfig-utils": {
+			"version": "8.59.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.1.tgz",
+			"integrity": "sha512-/0nEyPbX7gRsk0Uwfe4ALwwgxuA66d/l2mhRDNlAvaj4U3juhUtJNq0DsY8M2AYwwb9rEq2hrC3IcIcEt++iJA==",
+			"dev": true,
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
+		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
+			"version": "8.59.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.1.tgz",
+			"integrity": "sha512-ZDCjgccSdYPw5Bxh+my4Z0lJU96ZDN7jbBzvmEn0FZx3RtU1C7VWl6NbDx94bwY3V5YsgwRzJPOgeY2Q/nLG8A==",
+			"dev": true,
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
+			"version": "8.59.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.1.tgz",
+			"integrity": "sha512-OUd+vJS05sSkOip+BkZ/2NS8RMxrAAJemsC6vU3kmfLyeaJT0TftHkV9mcx2107MmsBVXXexhVu4F0TZXyMl4g==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/project-service": "8.59.1",
+				"@typescript-eslint/tsconfig-utils": "8.59.1",
+				"@typescript-eslint/types": "8.59.1",
+				"@typescript-eslint/visitor-keys": "8.59.1",
+				"debug": "^4.4.3",
+				"minimatch": "^10.2.2",
+				"semver": "^7.7.3",
+				"tinyglobby": "^0.2.15",
+				"ts-api-utils": "^2.5.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
+		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
+			"version": "8.59.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.1.tgz",
+			"integrity": "sha512-LdDNl6C5iJExcM0Yh0PwAIBb9PrSiCsWamF/JyEZawm3kFDnRoaq3LGE4bpyRao/fWeGKKyw7icx0YxrLFC5Cg==",
+			"dev": true,
+			"dependencies": {
+				"@typescript-eslint/types": "8.59.1",
+				"eslint-visitor-keys": "^5.0.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/parser/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/@typescript-eslint/parser/node_modules/brace-expansion": {
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/@typescript-eslint/parser/node_modules/eslint-visitor-keys": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+			"integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+			"dev": true,
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/parser/node_modules/minimatch": {
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^5.0.5"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/@typescript-eslint/project-service": {
@@ -3792,16 +3951,109 @@
 			}
 		},
 		"@typescript-eslint/parser": {
-			"version": "8.59.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.0.tgz",
-			"integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
+			"version": "8.59.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.1.tgz",
+			"integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/scope-manager": "8.59.0",
-				"@typescript-eslint/types": "8.59.0",
-				"@typescript-eslint/typescript-estree": "8.59.0",
-				"@typescript-eslint/visitor-keys": "8.59.0",
+				"@typescript-eslint/scope-manager": "8.59.1",
+				"@typescript-eslint/types": "8.59.1",
+				"@typescript-eslint/typescript-estree": "8.59.1",
+				"@typescript-eslint/visitor-keys": "8.59.1",
 				"debug": "^4.4.3"
+			},
+			"dependencies": {
+				"@typescript-eslint/project-service": {
+					"version": "8.59.1",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.1.tgz",
+					"integrity": "sha512-+MuHQlHiEr00Of/IQbE/MmEoi44znZHbR/Pz7Opq4HryUOlRi+/44dro9Ycy8Fyo+/024IWtw8m4JUMCGTYxDg==",
+					"dev": true,
+					"requires": {
+						"@typescript-eslint/tsconfig-utils": "^8.59.1",
+						"@typescript-eslint/types": "^8.59.1",
+						"debug": "^4.4.3"
+					}
+				},
+				"@typescript-eslint/scope-manager": {
+					"version": "8.59.1",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.1.tgz",
+					"integrity": "sha512-LwuHQI4pDOYVKvmH2dkaJo6YZCSgouVgnS/z7yBPKBMvgtBvyLqiLy9Z6b7+m/TRcX1NFYUqZetI5Y+aT4GEfg==",
+					"dev": true,
+					"requires": {
+						"@typescript-eslint/types": "8.59.1",
+						"@typescript-eslint/visitor-keys": "8.59.1"
+					}
+				},
+				"@typescript-eslint/tsconfig-utils": {
+					"version": "8.59.1",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.1.tgz",
+					"integrity": "sha512-/0nEyPbX7gRsk0Uwfe4ALwwgxuA66d/l2mhRDNlAvaj4U3juhUtJNq0DsY8M2AYwwb9rEq2hrC3IcIcEt++iJA==",
+					"dev": true,
+					"requires": {}
+				},
+				"@typescript-eslint/types": {
+					"version": "8.59.1",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.1.tgz",
+					"integrity": "sha512-ZDCjgccSdYPw5Bxh+my4Z0lJU96ZDN7jbBzvmEn0FZx3RtU1C7VWl6NbDx94bwY3V5YsgwRzJPOgeY2Q/nLG8A==",
+					"dev": true
+				},
+				"@typescript-eslint/typescript-estree": {
+					"version": "8.59.1",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.1.tgz",
+					"integrity": "sha512-OUd+vJS05sSkOip+BkZ/2NS8RMxrAAJemsC6vU3kmfLyeaJT0TftHkV9mcx2107MmsBVXXexhVu4F0TZXyMl4g==",
+					"dev": true,
+					"requires": {
+						"@typescript-eslint/project-service": "8.59.1",
+						"@typescript-eslint/tsconfig-utils": "8.59.1",
+						"@typescript-eslint/types": "8.59.1",
+						"@typescript-eslint/visitor-keys": "8.59.1",
+						"debug": "^4.4.3",
+						"minimatch": "^10.2.2",
+						"semver": "^7.7.3",
+						"tinyglobby": "^0.2.15",
+						"ts-api-utils": "^2.5.0"
+					}
+				},
+				"@typescript-eslint/visitor-keys": {
+					"version": "8.59.1",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.1.tgz",
+					"integrity": "sha512-LdDNl6C5iJExcM0Yh0PwAIBb9PrSiCsWamF/JyEZawm3kFDnRoaq3LGE4bpyRao/fWeGKKyw7icx0YxrLFC5Cg==",
+					"dev": true,
+					"requires": {
+						"@typescript-eslint/types": "8.59.1",
+						"eslint-visitor-keys": "^5.0.0"
+					}
+				},
+				"balanced-match": {
+					"version": "4.0.4",
+					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+					"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+					"dev": true
+				},
+				"brace-expansion": {
+					"version": "5.0.5",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+					"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+					"dev": true,
+					"requires": {
+						"balanced-match": "^4.0.2"
+					}
+				},
+				"eslint-visitor-keys": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+					"integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+					"dev": true
+				},
+				"minimatch": {
+					"version": "10.2.5",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+					"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "^5.0.5"
+					}
+				}
 			}
 		},
 		"@typescript-eslint/project-service": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"@eslint/js": "^10.0.1",
 		"@types/node": "^25.6.0",
 		"@typescript-eslint/eslint-plugin": "^8.59.0",
-		"@typescript-eslint/parser": "^8.59.0",
+		"@typescript-eslint/parser": "^8.59.1",
 		"builtin-modules": "^5.1.0",
 		"esbuild": "0.28.0",
 		"eslint": "^10.0.1",


### PR DESCRIPTION
Replacement for Dependabot PR #851, which was closed after the daily run because its head branch was deleted while conflicted.\n\nI resolved the conflict with the matching @typescript-eslint/eslint-plugin 8.59.1 bump already on main.\n\nLocal checks run:\n- npm ci\n- npm run lint\n- npm run build\n\nHolding for Tim review because I touched the PR branch.